### PR TITLE
Correct ResponseBuilder Semigroup instance

### DIFF
--- a/library/Strelka/Core/ResponseBuilder.hs
+++ b/library/Strelka/Core/ResponseBuilder.hs
@@ -16,7 +16,8 @@ instance Monoid ResponseBuilder where
   mappend (ResponseBuilder fn1) (ResponseBuilder fn2) =
     ResponseBuilder (fn2 . fn1)
 
-instance Semigroup ResponseBuilder
+instance Semigroup ResponseBuilder where
+  (<>) = mappend
 
 
 {-|


### PR DESCRIPTION
The Semigroup instance for ResponseBuilder was missing, causing runtime errors with GHC 8.4.3.